### PR TITLE
fix warning message when PatientSexTag is missed

### DIFF
--- a/med2image/med2image.py
+++ b/med2image/med2image.py
@@ -129,7 +129,11 @@ class med2image(object):
         'SeriesDescriptionTag': {
             'action':           'attempting to parse DICOM header, ',
             'error':            'the DICOM file does not seem to contain a SeriesDescription tag.',
-            'exitCode':         45}
+            'exitCode':         45},
+        'PatientSexTag': {
+            'action':           'attempting to parse DICOM header, ',
+            'error':            'the DICOM file does not seem to contain a PatientSex tag.',
+            'exitCode':         46}
     }
 
     @staticmethod


### PR DESCRIPTION
Without this, the process exits when a PatientSexTag is missed in a DICOM.